### PR TITLE
Prevent click jacking

### DIFF
--- a/public/.htaccess
+++ b/public/.htaccess
@@ -66,3 +66,8 @@ DirectoryIndex index.php
         # RedirectTemp cannot be used instead
     </IfModule>
 </IfModule>
+
+<IfModule mod_headers.c>
+    # Prevent clickjacking
+    Header set X-Frame-Options SAMEORIGIN
+</IfModule>


### PR DESCRIPTION
Actually, there is no protection against click-jacking. Given the nature of the platform (credentials, credit cards informations ecc) i think that this should be the default behavior.
What do you think?

Doc reference: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options